### PR TITLE
add backend_name in printer removed ; add printer_id to cancelJob

### DIFF
--- a/org.openprinting.Backend.xml
+++ b/org.openprinting.Backend.xml
@@ -10,8 +10,9 @@
             <arg name="printer_state" direction="out" type="s" />
             <arg name="backend_name" direction="out" type="s"/>
         </signal>
-        <signal name="PrinterRemoved">
+	<signal name="PrinterRemoved">
             <arg name="printer_id" type="s" direction="out"/>
+            <arg name="backend_name" type="s" direction="out"/>
         </signal>
         <method name="GetBackendName">
             <arg name="backend_name" direction="out" type="s" />

--- a/org.openprinting.Backend.xml
+++ b/org.openprinting.Backend.xml
@@ -43,7 +43,7 @@
             <arg name="active_only" direction="in" type="b"/>
             <arg name="num_jobs" direction="out" type="i"/>
             <arg name="jobs" direction="out" type="a(ssssssi)"/>
-            <!--job contents: job-id , title, printer, user, state , submitted at , size -->
+            <!--job contents: job-id , title, printer-id, user, state , submitted at(time string) , size -->
         </method>
         <method name="cancelJob">
             <arg name="job_id" direction="in" type="s"/>

--- a/org.openprinting.Backend.xml
+++ b/org.openprinting.Backend.xml
@@ -47,6 +47,7 @@
         </method>
         <method name="cancelJob">
             <arg name="job_id" direction="in" type="s"/>
+            <arg name="printer_id" direction="in" type="s"/>
             <arg name="status" direction="out" type="b"/>
         </method>
         <method name="printFile">


### PR DESCRIPTION
Added backend name as argument because the frontend needs that to figure out the hashtable key.
backend_name is similar as in printer added ( "CUPS"/"GCP")
Also, 
printer-id(destination name,i.e) is required by cups to find a print job. So please allow adding that too. You may leave the field unused.